### PR TITLE
Add setter function for width and height

### DIFF
--- a/js/window.js
+++ b/js/window.js
@@ -87,6 +87,9 @@ class Window extends EventEmitter {
 	
 	get width() { return this._width; }
 	get height() { return this._height; }
+
+	set width(w)  { this._width = w; }
+	set height(h) { this._height = h; }
 	
 	get w() { return this.width; }
 	get h() { return this.height; }


### PR DESCRIPTION
Threejs crashes when calling setSize() under the new API without a setter function for width and height