### PR TITLE
fix window.pos setter

### DIFF
--- a/js/window.js
+++ b/js/window.js
@@ -196,7 +196,7 @@ class Window extends EventEmitter {
 		}
 		this._x = x;
 		this._y = y;
-		glfw.setWindowSize(this._window, x, y);
+		glfw.setWindowPos(this._window, x, y);
 	}
 	
 	


### PR DESCRIPTION
setting `window.pos` should call `glfw.setWindowPos()` instead of `glfw.setWindowSize()`