### PR TITLE
Add resizable property for Window

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -324,7 +324,10 @@ declare module "glfw-raub" {
 		
 		/** An Object, containing PHYSICAL width and height of the window. */
 		size: TSize;
-		
+
+		/** Boolean, sets window resizability */
+		resizable: boolean;
+
 		/**
 		 * Alias for .on('keydown', cb).
 		 *

--- a/index.d.ts
+++ b/index.d.ts
@@ -147,6 +147,8 @@ declare module "glfw-raub" {
 		icon: TImageData;
 		/** If window has borders (use `false` for borderless fullscreen). Default is true. */
 		title: string;
+		/** Make window resizable. Default is false. */
+		resizable: boolean;
 		/**
 		 * This callback is called right before the window creation.
 		 *

--- a/index.d.ts
+++ b/index.d.ts
@@ -147,7 +147,7 @@ declare module "glfw-raub" {
 		icon: TImageData;
 		/** If window has borders (use `false` for borderless fullscreen). Default is true. */
 		title: string;
-		/** Make window resizable. Default is false. */
+		/** Make window resizable. Default is true. */
 		resizable: boolean;
 		/**
 		 * This callback is called right before the window creation.

--- a/js/window.js
+++ b/js/window.js
@@ -48,11 +48,13 @@ class Window extends EventEmitter {
 		}
 		
 		this._msaa = opts.msaa === undefined ? 2 : opts.msaa;
+
+		this._resizable = opts.resizable === false ? false : true;
 		
 		glfw.windowHint(glfw.CONTEXT_VERSION_MAJOR, this._major);
 		glfw.windowHint(glfw.CONTEXT_VERSION_MINOR, this._minor);
 		
-		glfw.windowHint(glfw.RESIZABLE, glfw.TRUE);
+		glfw.windowHint(glfw.RESIZABLE, this._resizable ? glfw.TRUE : glfw.FALSE);
 		glfw.windowHint(glfw.VISIBLE, glfw.TRUE);
 		glfw.windowHint(glfw.RED_BITS, 8);
 		glfw.windowHint(glfw.GREEN_BITS, 8);

--- a/js/window.js
+++ b/js/window.js
@@ -357,6 +357,17 @@ class Window extends EventEmitter {
 		glfw.setWindowSize(this._window, width, height);
 	}
 	
+	get resizable() {
+		const resizable = glfw.getWindowAttrib(this._window, glfw.RESIZABLE);
+		this._resizable = resizable === 1 ? true : false;
+		
+		return this._resizable;
+	}
+
+	set resizable(v) {
+		this._resizable = v;
+		glfw.setWindowAttrib(this._window, glfw.RESIZABLE, this._resizable ? glfw.TRUE : glfw.FALSE);
+	}
 	
 	get scrollX() { return 0; }
 	get scrollY() { return 0; }

--- a/js/window.js
+++ b/js/window.js
@@ -359,7 +359,7 @@ class Window extends EventEmitter {
 	
 	get resizable() {
 		const resizable = glfw.getWindowAttrib(this._window, glfw.RESIZABLE);
-		this._resizable = resizable === 1 ? true : false;
+		this._resizable = !!resizable;
 		
 		return this._resizable;
 	}


### PR DESCRIPTION
This change makes it possible to set window resizability both during window creation and afterwards by adding `resizable` property for `Window` and `TWindowOpts`.

Defaults to `true` to maintain current default behaviour.